### PR TITLE
Fix email confirmation PKCE flow

### DIFF
--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,30 +1,48 @@
 import { createClient } from "@/lib/supabase/server";
 import { type EmailOtpType } from "@supabase/supabase-js";
-import { redirect } from "next/navigation";
+import { NextResponse } from "next/server";
 import { type NextRequest } from "next/server";
 
 export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
   const token_hash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/";
 
-  if (token_hash && type) {
-    const supabase = await createClient();
+  const supabase = await createClient();
 
-    const { error } = await supabase.auth.verifyOtp({
-      type,
-      token_hash,
-    });
+  // PKCE flow — Supabase redirects with a `code` param
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      // redirect user to specified redirect URL or root of app
-      redirect(next);
-    } else {
-      // redirect the user to an error page with some instructions
-      redirect(`/auth/error?error=${error?.message}`);
+      const forwardedHost = request.headers.get("x-forwarded-host");
+      const isLocalEnv = process.env.NODE_ENV === "development";
+      if (isLocalEnv) {
+        return NextResponse.redirect(`${origin}${next}`);
+      } else if (forwardedHost) {
+        return NextResponse.redirect(`https://${forwardedHost}${next}`);
+      } else {
+        return NextResponse.redirect(`${origin}${next}`);
+      }
     }
+    return NextResponse.redirect(
+      `${origin}/auth/error?error=${encodeURIComponent(error.message)}`
+    );
   }
 
-  // redirect the user to an error page with some instructions
-  redirect(`/auth/error?error=No token hash or type`);
+  // Token hash flow fallback
+  if (token_hash && type) {
+    const { error } = await supabase.auth.verifyOtp({ type, token_hash });
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+    return NextResponse.redirect(
+      `${origin}/auth/error?error=${encodeURIComponent(error.message)}`
+    );
+  }
+
+  return NextResponse.redirect(
+    `${origin}/auth/error?error=${encodeURIComponent("No token hash or type")}`
+  );
 }


### PR DESCRIPTION
## Summary
- The `/auth/confirm` callback only handled the legacy `token_hash`/`type` flow (via `verifyOtp`), but `@supabase/ssr` uses **PKCE by default**, which sends a `code` query parameter instead
- Added `exchangeCodeForSession(code)` as the primary auth confirmation path, with the existing `verifyOtp` kept as a fallback
- Switched from `redirect()` to `NextResponse.redirect()` with `x-forwarded-host` awareness for correct behavior behind Vercel's load balancer

## Test plan
- [ ] Deploy to preview and sign up with a new email
- [ ] Click the confirmation link in the Supabase email
- [ ] Verify redirect lands on `/drives` instead of `/auth/error`
- [ ] Verify password reset flow still works via `/auth/update-password`

🤖 Generated with [Claude Code](https://claude.com/claude-code)