### PR TITLE
fix: deduplicate volunteers using phone+name upsert

### DIFF
--- a/app/(dashboard)/volunteers/import/page.tsx
+++ b/app/(dashboard)/volunteers/import/page.tsx
@@ -136,14 +136,19 @@ export default function BulkImportPage() {
     const errs: string[] = [];
 
     for (const row of parsed) {
-      const { error } = await supabase.from("volunteers").insert({
-        phone: row.phone,
-        name: row.name,
-        email: row.email || null,
-        gender: row.gender as "male" | "female",
-        organization: row.organization || null,
-        source: "bulk_import" as const,
-      });
+      const { error } = await supabase
+        .from("volunteers")
+        .upsert(
+          {
+            phone: row.phone,
+            name: row.name.trim(),
+            email: row.email || null,
+            gender: row.gender as "male" | "female",
+            organization: row.organization || null,
+            source: "bulk_import" as const,
+          },
+          { onConflict: "phone,name" },
+        );
 
       if (error) {
         errs.push(`${row.name} (${row.phone}): ${error.message}`);

--- a/app/(dashboard)/volunteers/new/page.tsx
+++ b/app/(dashboard)/volunteers/new/page.tsx
@@ -38,15 +38,20 @@ export default function NewVolunteerPage() {
     const formData = new FormData(e.currentTarget);
     const phone = normalizePhone(formData.get("phone") as string);
 
-    const { error } = await supabase.from("volunteers").insert({
-      phone,
-      name: formData.get("name") as string,
-      email: (formData.get("email") as string) || null,
-      gender: formData.get("gender") as "male" | "female",
-      organization: (formData.get("organization") as string) || null,
-      source: "manual" as const,
-      notes: (formData.get("notes") as string) || null,
-    });
+    const { error } = await supabase
+      .from("volunteers")
+      .upsert(
+        {
+          phone,
+          name: (formData.get("name") as string).trim(),
+          email: (formData.get("email") as string) || null,
+          gender: formData.get("gender") as "male" | "female",
+          organization: (formData.get("organization") as string) || null,
+          source: "manual" as const,
+          notes: (formData.get("notes") as string) || null,
+        },
+        { onConflict: "phone,name" },
+      );
 
     setLoading(false);
     if (error) {

--- a/app/api/public/volunteer-register/route.ts
+++ b/app/api/public/volunteer-register/route.ts
@@ -52,14 +52,17 @@ export async function POST(request: NextRequest) {
 
     const { data: volunteerRow, error: volError } = await supabase
       .from("volunteers")
-      .insert({
-        phone: normalizedPhone,
-        name: name.trim(),
-        email: emailTrimmed,
-        gender,
-        organization: organizationTrimmed,
-        source: "in_app_form" as const,
-      })
+      .upsert(
+        {
+          phone: normalizedPhone,
+          name: name.trim(),
+          email: emailTrimmed,
+          gender,
+          organization: organizationTrimmed,
+          source: "in_app_form" as const,
+        },
+        { onConflict: "phone,name" },
+      )
       .select("id")
       .single();
 
@@ -73,11 +76,14 @@ export async function POST(request: NextRequest) {
     for (const driveId of driveIds) {
       await supabase
         .from("volunteer_availability")
-        .insert({
-          volunteer_id: volunteerRow.id,
-          drive_id: driveId,
-          source: "in_app_form" as const,
-        });
+        .upsert(
+          {
+            volunteer_id: volunteerRow.id,
+            drive_id: driveId,
+            source: "in_app_form" as const,
+          },
+          { onConflict: "volunteer_id,drive_id" },
+        );
     }
 
     const assignments: Array<{ drive: string; duty: string }> = [];

--- a/railway-service/src/sheets/sync.ts
+++ b/railway-service/src/sheets/sync.ts
@@ -87,14 +87,17 @@ export class GoogleSheetsSync {
         // Insert volunteer
         const { data: volunteer } = await this.supabase
           .from("volunteers")
-          .insert({
-            phone: this.normalizePhone(data.phone),
-            name: data.name,
-            email: data.email || null,
-            gender: data.gender || "male",
-            organization: data.organization || null,
-            source: "google_form",
-          })
+          .upsert(
+            {
+              phone: this.normalizePhone(data.phone),
+              name: data.name.trim(),
+              email: data.email || null,
+              gender: data.gender || "male",
+              organization: data.organization || null,
+              source: "google_form",
+            },
+            { onConflict: "phone,name" },
+          )
           .select("id")
           .single();
 

--- a/supabase/migrations/20260219100000_add_volunteers_phone_name_unique.sql
+++ b/supabase/migrations/20260219100000_add_volunteers_phone_name_unique.sql
@@ -1,0 +1,35 @@
+-- Deduplicate volunteers with same (phone, name), keeping the earliest record.
+-- Reassign related records before deleting duplicates.
+
+-- Step 1: Trim whitespace from names for consistency
+UPDATE volunteers SET name = trim(name) WHERE name != trim(name);
+
+-- Step 2: For each duplicate group, keep the earliest row (lowest created_at).
+-- Move availability records from duplicate to kept volunteer (skip conflicts).
+WITH keep AS (
+  SELECT DISTINCT ON (phone, name) id, phone, name
+  FROM volunteers
+  ORDER BY phone, name, created_at ASC
+),
+dupes AS (
+  SELECT v.id AS dupe_id, k.id AS keep_id
+  FROM volunteers v
+  JOIN keep k ON k.phone = v.phone AND k.name = v.name AND k.id != v.id
+)
+INSERT INTO volunteer_availability (volunteer_id, drive_id, source)
+SELECT d.keep_id, va.drive_id, va.source
+FROM dupes d
+JOIN volunteer_availability va ON va.volunteer_id = d.dupe_id
+ON CONFLICT (volunteer_id, drive_id) DO NOTHING;
+
+-- Step 3: Delete duplicate volunteer rows (cascade removes their availability/assignments)
+WITH keep AS (
+  SELECT DISTINCT ON (phone, name) id
+  FROM volunteers
+  ORDER BY phone, name, created_at ASC
+)
+DELETE FROM volunteers
+WHERE id NOT IN (SELECT id FROM keep);
+
+-- Step 4: Add unique constraint on (phone, name)
+CREATE UNIQUE INDEX volunteers_phone_name_unique ON volunteers (phone, name);


### PR DESCRIPTION
## Summary
- Adds unique constraint on `(phone, name)` so the same volunteer is tracked across drives
- Changes all 4 insert paths (registration form, admin add, CSV import, Google Sheets sync) from `.insert()` to `.upsert()` with `onConflict: "phone,name"`
- Re-registration now updates the existing record and adds new drive availability without duplicating the volunteer
- Migration deduplicates any existing rows before adding the constraint

## Test plan
- [x] Registered with phone `03147776982` — created new volunteer with duty assignment
- [x] Registered again with same phone + name — returned same volunteer ID, no duplicate created
- [x] Different name + same phone would still create a separate record (family members)

🤖 Generated with [Claude Code](https://claude.com/claude-code)