### PR TITLE
fix: WhatsApp reconnect backoff + message retry logic

### DIFF
--- a/supabase/migrations/20260220100000_add_scheduled_messages_retry.sql
+++ b/supabase/migrations/20260220100000_add_scheduled_messages_retry.sql
@@ -1,0 +1,8 @@
+-- Add retry support to scheduled_messages
+alter table public.scheduled_messages
+  add column if not exists retry_count integer not null default 0;
+
+-- Index for the cron job: find failed messages eligible for retry
+create index if not exists idx_scheduled_messages_retry
+  on public.scheduled_messages (scheduled_at)
+  where status = 'failed' and retry_count < 3;


### PR DESCRIPTION
## Summary
- **WhatsApp reconnect fix**: Logs disconnect status code, uses exponential backoff (5s→80s), stops after 5 failures and clears auth state for fresh QR scan
- **Message retry logic**: Failed scheduled messages retry up to 3 times within 24 hours. Cron skips sending when WhatsApp is disconnected to avoid marking messages as failed unnecessarily
- Adds `retry_count` column to `scheduled_messages` table

## Test plan
- [ ] Deploy to Railway, check logs show disconnect reason (status code + error)
- [ ] Verify reconnect loop stops after 5 attempts
- [ ] Re-scan QR from admin panel after auth state is cleared
- [ ] Verify failed messages get retried once WhatsApp reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)