### PR TITLE
feat: add PostHog analytics to volunteer registration form

### DIFF
--- a/app/api/public/volunteer-register/route.ts
+++ b/app/api/public/volunteer-register/route.ts
@@ -128,6 +128,14 @@ export async function POST(request: NextRequest) {
         drive_count: driveIds.length,
         assignments_count: assignments.length,
         source: "in_app_form",
+        $set: {
+          gender,
+          organization: organizationTrimmed || null,
+          source: "in_app_form",
+        },
+        $set_once: {
+          first_registration_date: new Date().toISOString(),
+        },
       },
     });
 


### PR DESCRIPTION
## Summary
- Adds 9 client-side PostHog events to the `/join` volunteer registration form covering the full funnel: form viewed → phone submitted → drives selected → form submitted → registration success/failure
- Adds `posthog.identify()` after successful registration to link anonymous sessions to volunteer IDs
- Masks PII fields (phone, name, email) with `ph-no-capture` for session replay privacy
- Enhances server-side `public_volunteer_registered` event with `$set`/`$set_once` person properties
- Created PostHog dashboard with funnel, success/failure trends, and gender breakdown insights

## Test plan
- [ ] Run `npm run dev`, open `/join` with browser DevTools console
- [ ] Verify `volunteer_form_viewed` fires on page load (PostHog debug mode logs to console)
- [ ] Submit phone number and verify `volunteer_phone_submitted` fires (or `volunteer_no_drives_available` / `volunteer_phone_failed`)
- [ ] Toggle drive selections and verify `volunteer_drives_selected` fires with correct counts
- [ ] Submit form and verify `volunteer_form_submitted` → `volunteer_registration_success` fire with `time_spent_seconds`
- [ ] Confirm PII inputs have `ph-no-capture` class in DOM inspector
- [ ] Check [PostHog dashboard](https://us.posthog.com/project/318300/dashboard/1293511) populates after test events

🤖 Generated with [Claude Code](https://claude.com/claude-code)